### PR TITLE
Moves path rejection check and simplifies general rejection logic

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -370,6 +370,8 @@ function getHandler(options, proxy) {
     }
 
     let matchesPathAllowListItem = false;
+    let isInDestinationAllowlist = corsAnywhere.destinationAllowlist.length && corsAnywhere.destinationAllowlist.indexOf(location.hostname) !== -1;
+
     if (Object.keys(corsAnywhere.pathAllowlist).length > 0) {
       const allowedPaths = corsAnywhere.pathAllowlist[location.hostname];
       if (allowedPaths) {
@@ -381,23 +383,19 @@ function getHandler(options, proxy) {
             break;
           }
         }
-      }
-
-      if (!matchesPathAllowListItem) {
-        res.writeHead(403, 'Forbidden', cors_headers);
-        res.end('The destination "' + location.hostname + '" with path "' + location.path + '" is not allowed.');
-        return;
-      }
-    }
-
-    if (
-      (corsAnywhere.destinationAllowlist.length && 
-      corsAnywhere.destinationAllowlist.indexOf(location.hostname) === -1) &&
-      !matchesPathAllowListItem){
-        res.writeHead(403, 'Forbidden', cors_headers);
-        res.end('The destination "' + location.hostname + '" was not allow-listed.');
-        return;
-        
+         
+        if (!matchesPathAllowListItem) {
+          res.writeHead(403, 'Forbidden', cors_headers);
+          res.end('The destination "' + location.hostname + '" with path "' + location.path + '" is not allowed.');
+          return;
+        }
+      } // end of if allowedPaths
+    } // end of if pathAllowlist
+    
+    if (!matchesPathAllowListItem && !isInDestinationAllowlist) {
+      res.writeHead(403, 'Forbidden', cors_headers);
+      res.end('The destination "' + location.hostname + '" was not allow-listed.');
+      return;
     }
 
 


### PR DESCRIPTION
The rejection check for paths that were subject to more detailed path allow checks was rejecting requests to the more broadly allowed fully allowed hostnames. this moves the rejecting block and simplifies the general check too.