### PR TITLE
Add freecords.bubbleapps.io to destinationAllowlist.txt

### DIFF
--- a/conf/destinationAllowlist.txt
+++ b/conf/destinationAllowlist.txt
@@ -33,3 +33,4 @@ www.googleapis.com # For YouTube and Google Drive etc
 kendraio-dev-shop.myshopify.com # Shopify Store for testing purpose
 leanintoclean.com # Shopify API
 api.baserow.io # Baserow database API
+freecords.bubbleapps.io # Freecords API


### PR DESCRIPTION
In order to leverage the Freecords API, we need to add Freecords API to the Destination Allowlist.

Line added at the end of destinationAllowlist.txt (line 38) - 

`freecords.bubbleapps.io # Freecords API`